### PR TITLE
Add scrollbar to UI Data tab

### DIFF
--- a/src/UILayer/Packet/BatteryFaultsTab.ui
+++ b/src/UILayer/Packet/BatteryFaultsTab.ui
@@ -10,490 +10,486 @@
     <height>706</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>823</width>
+    <height>706</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QGroupBox" name="batteryLimitFlagsGroup">
-   <property name="geometry">
-    <rect>
-     <x>360</x>
-     <y>10</y>
-     <width>401</width>
-     <height>631</height>
-    </rect>
-   </property>
-   <property name="title">
-    <string>Limit Flags</string>
-   </property>
-   <widget class="QCheckBox" name="dclReducedLowSoc">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>30</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL Reduced Due to Low SOC</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclReducedHighCellResistance">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>60</y>
-      <width>311</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL Reduced Due to High Cell Resistance</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclReducedTemp">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>90</y>
-      <width>291</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL Reduced Due to Temperature</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclReducedLowCellVoltage">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>120</y>
-      <width>301</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL Reduced Due to Low Cell Voltage</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclReducedLowPackVoltage">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>150</y>
-      <width>301</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL Reduced Due to Low Pack Voltage</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclCclReducedCommsFailsafe">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>210</y>
-      <width>411</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL and CCL Reduced Due to Communication Failsafe</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dclCclReducedVoltageFailsafe">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>180</y>
-      <width>361</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DCL and CCL Reduced due to Voltage Failsafe</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedHighSoc">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>240</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to High SOC</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedHighCellResistance">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>270</y>
-      <width>381</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to High Cell Resistance</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedTemp">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>300</y>
-      <width>301</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to Temperature</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedHighCellVoltage">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>330</y>
-      <width>351</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to High Cell Voltage</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedHighPackVoltage">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>360</y>
-      <width>331</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to High Pack Voltage</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedChargerLatch">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>390</y>
-      <width>341</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to Charger Latch</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="cclReducedACLimit">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>420</y>
-      <width>371</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CCL Reduced Due to Alternate Current Limit [MPI]</string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QGroupBox" name="batteryErrorFlagsGroup">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>281</width>
-     <height>681</height>
-    </rect>
-   </property>
-   <property name="title">
-    <string>Error Flags</string>
-   </property>
-   <widget class="QCheckBox" name="internalCommFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>30</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Internal Communication Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="weakCellFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>90</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Weak Cell Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="lowCellVoltageFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>120</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Low Cell Voltage Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="openWiringFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>150</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Open Wiring Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="currentSensorFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>180</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Current Sensor Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="packVoltageSensor">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>210</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Pack Voltage Sensor</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="weakPackFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>240</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Weak Pack Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="voltageRedundancyFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>270</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Voltage Redundancy Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="fanMonitorFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>300</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Fan Monitor Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="thermistorFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>330</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Thermistor Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="canbusCommsFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>360</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CANBUS Communications Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="chargerSafetyRelayFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>540</y>
-      <width>261</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Charger Safety Relay Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="powerSupplyFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>450</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Power Supply Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="highVoltageIsolationFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>420</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>High Voltage Isolation Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="dischargeLimitEnforcementFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>510</y>
-      <width>261</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Discharge Limit Enforcement Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="chargeLimitEnforcementFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>480</y>
-      <width>241</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Charge Limit Enforcement Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="alwaysOnSupplyFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>390</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Always-On Supply Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="internalThermistorFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>600</y>
-      <width>261</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Internal Thermistor Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="internalLogicFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>630</y>
-      <width>261</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Internal Logic Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="internalMemoryFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>570</y>
-      <width>261</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Internal Memory Fault</string>
-    </property>
-   </widget>
-   <widget class="QCheckBox" name="internalConversionFault">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>60</y>
-      <width>231</width>
-      <height>23</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Internal Conversion Fault</string>
-    </property>
-   </widget>
-  </widget>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QGroupBox" name="batteryErrorFlagsGroup">
+     <property name="title">
+      <string>Error Flags</string>
+     </property>
+     <widget class="QCheckBox" name="internalCommFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Internal Communication Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="weakCellFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>90</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Weak Cell Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="lowCellVoltageFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>120</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Low Cell Voltage Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="openWiringFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>150</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Open Wiring Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="currentSensorFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>180</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Current Sensor Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="packVoltageSensor">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>210</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Pack Voltage Sensor</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="weakPackFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>240</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Weak Pack Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="voltageRedundancyFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>270</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Voltage Redundancy Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="fanMonitorFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>300</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Fan Monitor Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="thermistorFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>330</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Thermistor Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="canbusCommsFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>360</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CANBUS Communications Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="chargerSafetyRelayFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>540</y>
+        <width>261</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Charger Safety Relay Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="powerSupplyFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>450</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Power Supply Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="highVoltageIsolationFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>420</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>High Voltage Isolation Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dischargeLimitEnforcementFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>510</y>
+        <width>261</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Discharge Limit Enforcement Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="chargeLimitEnforcementFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>480</y>
+        <width>241</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Charge Limit Enforcement Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="alwaysOnSupplyFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>390</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Always-On Supply Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="internalThermistorFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>600</y>
+        <width>261</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Internal Thermistor Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="internalLogicFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>630</y>
+        <width>261</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Internal Logic Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="internalMemoryFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>570</y>
+        <width>261</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Internal Memory Fault</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="internalConversionFault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Internal Conversion Fault</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="batteryLimitFlagsGroup">
+     <property name="title">
+      <string>Limit Flags</string>
+     </property>
+     <widget class="QCheckBox" name="dclReducedLowSoc">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL Reduced Due to Low SOC</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclReducedHighCellResistance">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>311</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL Reduced Due to High Cell Resistance</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclReducedTemp">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>90</y>
+        <width>291</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL Reduced Due to Temperature</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclReducedLowCellVoltage">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>120</y>
+        <width>301</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL Reduced Due to Low Cell Voltage</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclReducedLowPackVoltage">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>150</y>
+        <width>301</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL Reduced Due to Low Pack Voltage</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclCclReducedCommsFailsafe">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>210</y>
+        <width>411</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL and CCL Reduced Due to Communication Failsafe</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="dclCclReducedVoltageFailsafe">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>180</y>
+        <width>361</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DCL and CCL Reduced due to Voltage Failsafe</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedHighSoc">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>240</y>
+        <width>231</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to High SOC</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedHighCellResistance">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>270</y>
+        <width>381</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to High Cell Resistance</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedTemp">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>300</y>
+        <width>301</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to Temperature</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedHighCellVoltage">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>330</y>
+        <width>351</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to High Cell Voltage</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedHighPackVoltage">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>360</y>
+        <width>331</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to High Pack Voltage</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedChargerLatch">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>390</y>
+        <width>341</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to Charger Latch</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cclReducedACLimit">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>420</y>
+        <width>371</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CCL Reduced Due to Alternate Current Limit [MPI]</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/UILayer/PacketWindow.cpp
+++ b/src/UILayer/PacketWindow.cpp
@@ -24,6 +24,11 @@ PacketWindow::PacketWindow()
     , mpptTab_(new MpptTab())
 {
     tabs_ = new QTabWidget();
+
+    scroll_ = new QScrollArea();
+    scroll_->setWidget(tabs_);
+    scroll_->setWidgetResizable(true);
+
     tabs_->addTab(auxBmsTab_.data(), tr("Aux BMS"));
     tabs_->addTab(batteryTab_.data(), tr("Battery"));
     tabs_->addTab(batteryFaultsTab_.data(), tr("Battery Faults"));
@@ -40,7 +45,7 @@ PacketWindow::PacketWindow()
     setPacket1_ = new QPushButton("Set Packet 1", this);
     tabsLayout->addWidget(setPacket0_);
     tabsLayout->addWidget(setPacket1_);
-    tabsLayout->addWidget(tabs_);
+    tabsLayout->addWidget(scroll_);
     setLayout(tabsLayout);
     setWindowTitle(tr("Data"));
 }

--- a/src/UILayer/PacketWindow.h
+++ b/src/UILayer/PacketWindow.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 #include <QTabWidget>
 #include <QPushButton>
+#include <QScrollArea>
 #include <QScopedPointer>
 
 class AuxBmsTab;
@@ -48,6 +49,6 @@ private:
     QScopedPointer<MpptTab> mpptTab_;
     QPushButton* setPacket0_;
     QPushButton* setPacket1_;
-
+    QScrollArea* scroll_;
 };
 


### PR DESCRIPTION
This adds a scrollbar to the UI Data tab when overflowing.
Note: This scrollbar scales to the Battery Faults tab, which is currently the largest tab. If a larger tab is added, scrollbar may not work as intended

This commit fixes #61 