### PR TITLE
Fix for High DPI Screens

### DIFF
--- a/src/TelemTestToolMain/main.cpp
+++ b/src/TelemTestToolMain/main.cpp
@@ -7,6 +7,10 @@
 
 int main(int argc, char** argv)
 {
+    #if QT_VERSION >= 0x050600
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    #endif
+
     TestApplication a(argc, argv);
     return a.exec();
 }


### PR DESCRIPTION
Note: This only works on QT 5.6+. Macro prevents building the new code with any QT version < 5.6