### PR TITLE
SFT-78 Change test tool to take decimal input under MPPT Tab

### DIFF
--- a/src/BusinessLayer/SerialReporting.cpp
+++ b/src/BusinessLayer/SerialReporting.cpp
@@ -349,9 +349,16 @@ void SerialReporting::sendMppt()
 
     for (unsigned char i = 0; i < CcsDefines::MPPT_COUNT; i++)
     {
-        writeUShortIntoArray(packetPayload, 2, dataContainerList[packetNum_]->getMpptData().arrayVoltage() * ONES_TO_CENTI);
-        writeUShortIntoArray(packetPayload, 4, dataContainerList[packetNum_]->getMpptData().arrayCurrent() * ONES_TO_MILLI);
-        writeUShortIntoArray(packetPayload, 6, dataContainerList[packetNum_]->getMpptData().batteryVoltage() * ONES_TO_CENTI);
+
+        unsigned short arrayVoltage = (unsigned short)(dataContainerList[packetNum_]->getMpptData().arrayVoltage() * ONES_TO_CENTI);
+        writeUShortIntoArray(packetPayload, 2, arrayVoltage);
+
+        unsigned short arrayCurrent = (unsigned short)(dataContainerList[packetNum_]->getMpptData().arrayCurrent() * ONES_TO_MILLI);
+        writeUShortIntoArray(packetPayload, 4, arrayCurrent);
+
+        unsigned short batteryVoltage = (unsigned short)(dataContainerList[packetNum_]->getMpptData().batteryVoltage() * ONES_TO_CENTI);
+        writeUShortIntoArray(packetPayload, 6, batteryVoltage);
+
         writeUShortIntoArray(packetPayload, 8, dataContainerList[packetNum_]->getMpptData().temperature() * ONES_TO_CENTI);
         unsigned char mpptPacketPayload[unframedPacketLength];
         std::memcpy(mpptPacketPayload, packetPayload, unframedPacketLength);

--- a/src/DataLayer/MpptData.cpp
+++ b/src/DataLayer/MpptData.cpp
@@ -19,17 +19,17 @@ bool MpptData::alive() const
     return alive_;
 }
 
-unsigned short MpptData::arrayVoltage() const
+double MpptData::arrayVoltage() const
 {
     return arrayVoltage_;
 }
 
-unsigned short MpptData::arrayCurrent() const
+double MpptData::arrayCurrent() const
 {
     return arrayCurrent_;
 }
 
-unsigned short MpptData::batteryVoltage() const
+double MpptData::batteryVoltage() const
 {
     return batteryVoltage_;
 }
@@ -44,17 +44,17 @@ void MpptData::setAlive(const bool& alive)
     alive_ = alive;
 }
 
-void MpptData::setArrayVoltage(const unsigned short& arrayVoltage)
+void MpptData::setArrayVoltage(const double& arrayVoltage)
 {
     arrayVoltage_ = arrayVoltage;
 }
 
-void MpptData::setArrayCurrent(const unsigned short& arrayCurrent)
+void MpptData::setArrayCurrent(const double& arrayCurrent)
 {
     arrayCurrent_ = arrayCurrent;
 }
 
-void MpptData::setBatteryVoltage(const unsigned short& batteryVoltage)
+void MpptData::setBatteryVoltage(const double& batteryVoltage)
 {
     batteryVoltage_ = batteryVoltage;
 }

--- a/src/DataLayer/MpptData.h
+++ b/src/DataLayer/MpptData.h
@@ -11,22 +11,22 @@ public:
     virtual ~MpptData();
 
     bool alive() const;
-    unsigned short arrayVoltage() const;
-    unsigned short arrayCurrent() const;
-    unsigned short batteryVoltage() const;
+    double arrayVoltage() const;
+    double arrayCurrent() const;
+    double batteryVoltage() const;
     unsigned short temperature() const;
 
     void setAlive(const bool& alive);
-    void setArrayVoltage(const unsigned short& arrayVoltage);
-    void setArrayCurrent(const unsigned short& arrayCurrent);
-    void setBatteryVoltage(const unsigned short& batteryVoltage);
+    void setArrayVoltage(const double& arrayVoltage);
+    void setArrayCurrent(const double& arrayCurrent);
+    void setBatteryVoltage(const double& batteryVoltage);
     void setTemperature(const unsigned short& temperature);
 
 private:
     unsigned char mpptNumber_;
     bool alive_;
-    unsigned short arrayVoltage_;
-    unsigned short arrayCurrent_;
-    unsigned short batteryVoltage_;
+    double arrayVoltage_;
+    double arrayCurrent_;
+    double batteryVoltage_;
     unsigned short temperature_;
 };

--- a/src/UILayer/Packet/MpptTab.cpp
+++ b/src/UILayer/Packet/MpptTab.cpp
@@ -18,17 +18,17 @@ QCheckBox& MpptTab::mpptAlive()
     return *ui_->mpptAlive;
 }
 
-QSpinBox& MpptTab::arrayCurrent()
+QDoubleSpinBox& MpptTab::arrayCurrent()
 {
     return *ui_->arrayCurrent;
 }
 
-QSpinBox& MpptTab::arrayVoltage()
+QDoubleSpinBox& MpptTab::arrayVoltage()
 {
     return *ui_->arrayVoltage;
 }
 
-QSpinBox& MpptTab::batteryVoltage()
+QDoubleSpinBox& MpptTab::batteryVoltage()
 {
     return *ui_->batteryVoltage;
 }

--- a/src/UILayer/Packet/MpptTab.h
+++ b/src/UILayer/Packet/MpptTab.h
@@ -2,6 +2,7 @@
 
 #include <QCheckBox>
 #include <QSpinBox>
+#include <QDoubleSpinBox>
 
 namespace Ui
 {
@@ -16,9 +17,9 @@ public:
     ~MpptTab();
 
     QCheckBox& mpptAlive();
-    QSpinBox& arrayCurrent();
-    QSpinBox& arrayVoltage();
-    QSpinBox& batteryVoltage();
+    QDoubleSpinBox& arrayCurrent();
+    QDoubleSpinBox& arrayVoltage();
+    QDoubleSpinBox& batteryVoltage();
     QSpinBox& mpptNumber();
     QSpinBox& temperature();
 

--- a/src/UILayer/Packet/MpptTab.ui
+++ b/src/UILayer/Packet/MpptTab.ui
@@ -52,7 +52,7 @@
     <string>Array Voltage</string>
    </property>
   </widget>
-  <widget class="QSpinBox" name="batteryVoltage">
+  <widget class="QDoubleSpinBox" name="batteryVoltage">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -61,11 +61,8 @@
      <height>26</height>
     </rect>
    </property>
-   <property name="maximum">
-    <number>65535</number>
-   </property>
   </widget>
-  <widget class="QSpinBox" name="arrayCurrent">
+  <widget class="QDoubleSpinBox" name="arrayCurrent">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -73,9 +70,6 @@
      <width>71</width>
      <height>26</height>
     </rect>
-   </property>
-   <property name="maximum">
-    <number>65535</number>
    </property>
   </widget>
   <widget class="QSpinBox" name="temperature">
@@ -91,7 +85,7 @@
     <number>65535</number>
    </property>
   </widget>
-  <widget class="QSpinBox" name="arrayVoltage">
+  <widget class="QDoubleSpinBox" name="arrayVoltage">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -99,9 +93,6 @@
      <width>71</width>
      <height>26</height>
     </rect>
-   </property>
-   <property name="maximum">
-    <number>65535</number>
    </property>
   </widget>
   <widget class="QLabel" name="label_32">


### PR DESCRIPTION
Under the Data/MPPT tab: Array Voltage, Array Current, and Battery
Voltage allow for decimal input in the form of double rather than
unsigned short